### PR TITLE
修复：扩大异常捕获范围，防止在解析非标准yml文件时发生异常导致后续逻辑无法执行。

### DIFF
--- a/src/main/java/com/wwr/apipost/util/CommonUtil.java
+++ b/src/main/java/com/wwr/apipost/util/CommonUtil.java
@@ -93,7 +93,7 @@ public class CommonUtil {
             if (server != null) {
                 return server.getStr("port");
             }
-        } catch (IOException e) {
+        } catch (Exception e) {
             e.printStackTrace();
         }
         return null;


### PR DESCRIPTION
若在配置中未配置“服务URL”时，插件将会尝试解析application.yml文件中的服务地址和端口配置。但在具备一定规模的工程中，yml中可能不会直接写服务端口号而是通过外部配置加载，yml文件中则用配置变量代替，插件无法解析此种非标准yml文件。在解析时将抛出异常，原来的异常捕获限定了仅能捕获IOException，导致解析文件的异常会层层向上抛出，这种层层抛出的行为将导致后续赋予默认服务器地址和端口号的逻辑无法正常执行。但从逻辑上看解析yml的过程是允许失败的。所以此处将异常捕获类型进行调整。
示例yml文件：
![image](https://github.com/Apipost-Team/Apipost-idea-plugin/assets/3636712/1bad42c5-3de9-4df6-a54d-ef7e935465dd)
